### PR TITLE
Update highs-sys and run CI on MacOS

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,10 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ repository = "https://github.com/rust-or/highs"
 keywords = ["linear-programming", "optimization", "math", "solver"]
 
 [dependencies]
-highs-sys = "1.5.0"
+highs-sys = "1.6.1"
 log = "0.4.17"


### PR DESCRIPTION
Enable CI on MacOS and update the highs-sys dependency

I didn't enable Windows yet, as I have hangs that seem non-deterministic. It seems related to [this thread](https://github.com/rust-or/highs-sys/issues/9). Note that similar issues happen with the current highs version as well, as can be seen in [this CI run](https://github.com/Coloquinte/volute/actions/runs/7385940657).

