### PR TITLE
Add iteration count method for SolverModel

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "workbench.colorCustomizations": {
-        "minimap.background": "#00000000",
-        "scrollbar.shadow": "#00000000"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "workbench.colorCustomizations": {
+        "minimap.background": "#00000000",
+        "scrollbar.shadow": "#00000000"
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -567,6 +567,12 @@ impl SolvedModel {
     fn num_rows(&self) -> usize {
         self.highs.num_rows().expect("invalid number of rows")
     }
+
+    /// Get the number of iterations
+    pub fn get_iteration_count(&self) -> i32 {
+        let iteration_count = unsafe { Highs_getIterationCount(self.highs.ptr())};
+        iteration_count
+    }
 }
 
 /// Concrete values of the solution

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -569,7 +569,7 @@ impl SolvedModel {
     }
 
     /// Get the number of iterations
-    pub fn get_iteration_count(&self) -> i32 {
+    pub fn iteration_count(&self) -> i32 {
         let iteration_count = unsafe { Highs_getIterationCount(self.highs.ptr())};
         iteration_count
     }


### PR DESCRIPTION
As mentioned in this [discussion](https://github.com/ERGO-Code/HiGHS/discussions/1787#discussioncomment-9651401), there was not a direct method to get the iteration count of the model. I made a very simple method to get it, as it happens also for the status of the model implemented in the same struct SolverModel i think it would be nice to have a function to have the iteration count without dealing with the unsafe code either cause there already an interface written to deal with the c bindings.