### PR TITLE
Add PartialEq, Eq, and Hash for Row and Col structs

### DIFF
--- a/src/matrix_col.rs
+++ b/src/matrix_col.rs
@@ -7,7 +7,7 @@ use std::os::raw::c_int;
 use crate::Problem;
 
 /// Represents a constraint
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Row(pub(crate) c_int);
 
 /// A constraint matrix to build column-by-column

--- a/src/matrix_row.rs
+++ b/src/matrix_row.rs
@@ -8,7 +8,7 @@ use crate::matrix_col::ColMatrix;
 use crate::Problem;
 
 /// Represents a variable
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Col(pub(crate) usize);
 
 /// A complete optimization problem stored by row


### PR DESCRIPTION
I've found this useful when creating problems with a large number of variables or constraints, so that I can manage  them and keep track of what they mean.

e.g. I have a `foos: Vec<Foo>` and I create a `variable: Col` with `problem.add_integer_column()` for each `foo in foos`. I'd like to be able to create a `HashMap<Col, &Foo>` so that I can keep track of which `Foo` corresponds to each `Col`.