### PR TITLE
docs: fix link to highs options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,7 @@ impl Model {
 
     /// Set a custom parameter on the model.
     /// For the list of available options and their documentation, see:
-    /// <https://www.maths.ed.ac.uk/hall/HiGHS/HighsOptions.html>
+    /// <https://ergo-code.github.io/HiGHS/dev/options/definitions/>
     ///
     /// ```
     /// # use highs::ColProblem;


### PR DESCRIPTION
The previously correct docs page now has a link from https://www.maths.ed.ac.uk/hall/HiGHS/#docs to the docs at https://ergo-code.github.io/HiGHS/dev/. The current code comment contains a dead link. This fixes that.