### PR TITLE
Add methods to `Model` and `SolvedModel` for exposing underlying pointer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -601,6 +601,16 @@ impl HighsPtr {
 }
 
 impl SolvedModel {
+    /// Return pointer to underlying HiGHS model
+    pub fn as_ptr(&self) -> *const c_void{
+        self.highs.ptr()
+    }
+
+    /// Return mutable pointer to underlying HiGHS model
+    pub fn as_mut_ptr(&mut self) -> *mut c_void{
+        self.highs.mut_ptr()
+    }
+
     /// The status of the solution. Should be Optimal if everything went well.
     pub fn status(&self) -> HighsModelStatus {
         let model_status = unsafe { Highs_getModelStatus(self.highs.unsafe_mut_ptr()) };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,16 @@ pub enum Sense {
 }
 
 impl Model {
+    /// Return pointer to underlying HiGHS model
+    pub fn as_ptr(&self) -> *const c_void{
+        self.highs.ptr()
+    }
+
+    /// Return mutable pointer to underlying HiGHS model
+    pub fn as_mut_ptr(&mut self) -> *mut c_void{
+        self.highs.mut_ptr()
+    }
+
     /// Set the optimization sense (minimize by default)
     pub fn set_sense(&mut self, sense: Sense) {
         let ret = unsafe { Highs_changeObjectiveSense(self.highs.mut_ptr(), sense as c_int) };


### PR DESCRIPTION
This PR adds methods to the `Model` and `SolvedModel` structs to access the underlying pointer used for the C API.

This allows users to access the full C API as exposed by the `highs-sys` crate, which may be needed to use features that are not currently exposed by this crate (e.g. #25).