### PR TITLE
Fix: `Model::try_set_option`: Return error if option name contains NUL char

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -733,7 +733,7 @@ impl HighsPtr {
         option: STR,
         value: V,
     ) -> Result<(), TrySetOptionError> {
-        let c_str = CString::new(option).expect("Option name contains NUL char");
+        let c_str = CString::new(option).map_err(|_| TrySetOptionError {})?;
         let status = unsafe { value.apply_to_highs(self.mut_ptr(), c_str.as_ptr()) };
         match try_handle_status(status, "Highs_setOptionValue") {
             Ok(_) => Ok(()),


### PR DESCRIPTION
This is just a small follow-on to #40.

Currently `Model::try_set_option` panics in the case that there is a NUL char in the option name, but there's no reason really to treat these bad option names as different from any other. Return an error in this case too.

It's probably unlikely that a user would do this, but we don't document that this function can panic, so let's make it safer by returning an error.
